### PR TITLE
fixed secure key to cart secure key to avoid fatal error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "prestashop/ps_wirepayment",
+  "name": "aliwister/ps_wirepayment",
   "description": "PrestaShop module ps_wirepayment",
   "homepage": "https://github.com/PrestaShop/ps_wirepayment",
   "license": "AFL - Academic Free License (AFL 3.0)",

--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -61,7 +61,7 @@ class Ps_WirepaymentValidationModuleFrontController extends ModuleFrontControlle
 			'{bankwire_address}' => nl2br(Configuration::get('BANK_WIRE_ADDRESS'))
 		);
 
-		$this->module->validateOrder($cart->id, Configuration::get('PS_OS_BANKWIRE'), $total, $this->module->displayName, NULL, $mailVars, (int)$currency->id, false, $customer->secure_key);
-		Tools::redirect('index.php?controller=order-confirmation&id_cart='.$cart->id.'&id_module='.$this->module->id.'&id_order='.$this->module->currentOrder.'&key='.$customer->secure_key);
+		$this->module->validateOrder($cart->id, Configuration::get('PS_OS_BANKWIRE'), $total, $this->module->displayName, NULL, $mailVars, (int)$currency->id, false, $cart->secure_key);
+		Tools::redirect('index.php?controller=order-confirmation&id_cart='.$cart->id.'&id_module='.$this->module->id.'&id_order='.$this->module->currentOrder.'&key='.$cart->secure_key);
 	}
 }

--- a/validation.php
+++ b/validation.php
@@ -58,7 +58,7 @@ if (!Validate::isLoadedObject($customer))
 $currency = $context->currency;
 $total = (float)($cart->getOrderTotal(true, Cart::BOTH));
 
-$bankwire->validateOrder($cart->id, Configuration::get('PS_OS_BANKWIRE'), $total, $bankwire->displayName, NULL, array(), (int)$currency->id, false, $customer->secure_key);
+$bankwire->validateOrder($cart->id, Configuration::get('PS_OS_BANKWIRE'), $total, $bankwire->displayName, NULL, array(), (int)$currency->id, false, $cart->secure_key);
 
 $order = new Order($bankwire->currentOrder);
 Tools::redirect('index.php?controller=order-confirmation&id_cart='.$cart->id.'&id_module='.$bankwire->id.'&id_order='.$bankwire->currentOrder.'&key='.$customer->secure_key);


### PR DESCRIPTION
PaymentModule checks if the secure key returned equals the cart secure key. When they're not equal, a fatal error occurs (PS 1.7). This is the fix we have made to avoid that.