### PR TITLE
MO : Deduction of amount already paid

### DIFF
--- a/ps_wirepayment.php
+++ b/ps_wirepayment.php
@@ -235,10 +235,11 @@ class Ps_Wirepayment extends PaymentModule
                 $bankwireAddress = '___________';
             }
 
+            $totalToPaid = $params['order']->getOrdersTotalPaid() - $params['order']->getTotalPaid();
             $this->smarty->assign(array(
                 'shop_name' => $this->context->shop->name,
                 'total' => Tools::displayPrice(
-                    $params['order']->getOrdersTotalPaid(),
+                    $totalToPaid,
                     new Currency($params['order']->id_currency),
                     false
                 ),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | An order can have other payment on the same order process we can have a payment that is made before (eg payment by gift card or balance / have), so it is necessary to deduct the amount that has already been paid. This update have visual impact for the final customer. I regularly implement this update near my clients.Maybe one day we will be able to make multiple payments, this update is a first step :-).
| Type?         | Feature
| Category?     | MO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | PrestaShop/PrestaShop#18413
| How to test?  |  Paid with wire payment and check amount.
