### PR TITLE
MO: Fix logic of reservation days

### DIFF
--- a/ps_wirepayment.php
+++ b/ps_wirepayment.php
@@ -424,7 +424,8 @@ class Ps_Wirepayment extends PaymentModule
         }
 
         $bankwireReservationDays = Configuration::get('BANK_WIRE_RESERVATION_DAYS');
-        if (false === $bankwireReservationDays) {
+        if ($bankwireReservationDays === false || $bankwireReservationDays === null) {
+            // When the value is not set, we set it to 7 days by default
             $bankwireReservationDays = 7;
         }
 

--- a/ps_wirepayment.php
+++ b/ps_wirepayment.php
@@ -424,7 +424,7 @@ class Ps_Wirepayment extends PaymentModule
         }
 
         $bankwireReservationDays = Configuration::get('BANK_WIRE_RESERVATION_DAYS');
-        if ($bankwireReservationDays === false || $bankwireReservationDays === null) {
+        if (empty($bankwireReservationDays)) {
             // When the value is not set, we set it to 7 days by default
             $bankwireReservationDays = 7;
         }

--- a/views/templates/hook/ps_wirepayment_intro.tpl
+++ b/views/templates/hook/ps_wirepayment_intro.tpl
@@ -26,7 +26,11 @@
 <section>
   <p>
     {l s='Please transfer the invoice amount to our bank account. You will receive our order confirmation by email containing bank details and order number.' d='Modules.Wirepayment.Shop'}
-    {l s='Goods will be reserved %s days for you and we\'ll process the order immediately after receiving the payment.' sprintf=[$bankwireReservationDays] d='Modules.Wirepayment.Shop'}
+
+    {if $bankwireReservationDays != 0}
+      {l s='Goods will be reserved %s days for you.' sprintf=[$bankwireReservationDays] d='Modules.Wirepayment.Shop'}
+    {/if}
+    {l s='We\'ll process the order immediately after receiving the payment.' sprintf=[$bankwireReservationDays] d='Modules.Wirepayment.Shop'}
     {if $bankwireCustomText }
         <a data-toggle="modal" data-target="#bankwire-modal">{l s='More information' d='Modules.Wirepayment.Shop'}</a>
     {/if}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | dev
| Description?  | Sometimes the module will display a **"0 days" reservation period** in step 4 of the checkout process.<br />This will be the case when the value of the "Reservation period" is not set (this field is not mandatory in the module configuration in BO).<br />Also, when the shop owner do not want to set a reservation period it should not display the message.
| Type?         |improvement
| Category?     | MO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install the module, do not configure the "Reservation period" and process an order till the step 4 (payment) in the checkout process.