### PR TITLE
Hide goods reservation text for empty days value

### DIFF
--- a/views/templates/hook/ps_wirepayment_intro.tpl
+++ b/views/templates/hook/ps_wirepayment_intro.tpl
@@ -26,7 +26,9 @@
 <section>
   <p>
     {l s='Please transfer the invoice amount to our bank account. You will receive our order confirmation by email containing bank details and order number.' d='Modules.Wirepayment.Shop'}
-    {l s='Goods will be reserved %s days for you and we\'ll process the order immediately after receiving the payment.' sprintf=[$bankwireReservationDays] d='Modules.Wirepayment.Shop'}
+    {if $bankwireReservationDays}
+      {l s='Goods will be reserved %s days for you and we\'ll process the order immediately after receiving the payment.' sprintf=[$bankwireReservationDays] d='Modules.Wirepayment.Shop'}
+    {/if}
     {if $bankwireCustomText }
         <a data-toggle="modal" data-target="#bankwire-modal">{l s='More information' d='Modules.Wirepayment.Shop'}</a>
     {/if}


### PR DESCRIPTION
If BANK_WIRE_RESERVATION_DAYS isn't set don't display any text to avoid
messages like:
"Goods will be reserved 0 days for you and we'll process the order
immediately after receiving the payment."