### PR TITLE
Clean legacy status check and template

### DIFF
--- a/ps_wirepayment.php
+++ b/ps_wirepayment.php
@@ -211,53 +211,35 @@ class Ps_Wirepayment extends PaymentModule
             return;
         }
 
-        $state = $params['order']->getCurrentState();
-        if (
-            in_array(
-                $state,
-                [
-                    Configuration::get('PS_OS_BANKWIRE'),
-                    Configuration::get('PS_OS_OUTOFSTOCK'),
-                    Configuration::get('PS_OS_OUTOFSTOCK_UNPAID'),
-                ]
-        )) {
-            $bankwireOwner = $this->owner;
-            if (!$bankwireOwner) {
-                $bankwireOwner = '___________';
-            }
-
-            $bankwireDetails = Tools::nl2br($this->details);
-            if (!$bankwireDetails) {
-                $bankwireDetails = '___________';
-            }
-
-            $bankwireAddress = Tools::nl2br($this->address);
-            if (!$bankwireAddress) {
-                $bankwireAddress = '___________';
-            }
-
-            $totalToPaid = $params['order']->getOrdersTotalPaid() - $params['order']->getTotalPaid();
-            $this->smarty->assign([
-                'shop_name' => $this->context->shop->name,
-                'total' => $this->context->getCurrentLocale()->formatPrice(
-                    $totalToPaid,
-                    (new Currency($params['order']->id_currency))->iso_code
-                ),
-                'bankwireDetails' => $bankwireDetails,
-                'bankwireAddress' => $bankwireAddress,
-                'bankwireOwner' => $bankwireOwner,
-                'status' => 'ok',
-                'reference' => $params['order']->reference,
-                'contact_url' => $this->context->link->getPageLink('contact', true),
-            ]);
-        } else {
-            $this->smarty->assign(
-                [
-                    'status' => 'failed',
-                    'contact_url' => $this->context->link->getPageLink('contact', true),
-                ]
-            );
+        $bankwireOwner = $this->owner;
+        if (!$bankwireOwner) {
+            $bankwireOwner = '___________';
         }
+
+        $bankwireDetails = Tools::nl2br($this->details);
+        if (!$bankwireDetails) {
+            $bankwireDetails = '___________';
+        }
+
+        $bankwireAddress = Tools::nl2br($this->address);
+        if (!$bankwireAddress) {
+            $bankwireAddress = '___________';
+        }
+
+        $totalToPaid = $params['order']->getOrdersTotalPaid() - $params['order']->getTotalPaid();
+        $this->smarty->assign([
+            'shop_name' => $this->context->shop->name,
+            'total' => $this->context->getCurrentLocale()->formatPrice(
+                $totalToPaid,
+                (new Currency($params['order']->id_currency))->iso_code
+            ),
+            'bankwireDetails' => $bankwireDetails,
+            'bankwireAddress' => $bankwireAddress,
+            'bankwireOwner' => $bankwireOwner,
+            'status' => 'ok',
+            'reference' => $params['order']->reference,
+            'contact_url' => $this->context->link->getPageLink('contact', true),
+        ]);
 
         return $this->fetch('module:ps_wirepayment/views/templates/hook/payment_return.tpl');
     }

--- a/views/templates/hook/payment_return.tpl
+++ b/views/templates/hook/payment_return.tpl
@@ -17,23 +17,17 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{if $status == 'ok'}
-    <p>
-      {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
-      {l s='Please send us a bank wire with:' d='Modules.Wirepayment.Shop'}
-    </p>
-    {include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}
+<p>
+  {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
+  {l s='Please send us a bank wire with:' d='Modules.Wirepayment.Shop'}
+</p>
+{include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}
 
-    <p>
-      {l s='Please specify your order reference %s in the bankwire description.' sprintf=[$reference] d='Modules.Wirepayment.Shop'}<br/>
-      {l s='We\'ve also sent you this information by e-mail.' d='Modules.Wirepayment.Shop'}
-    </p>
-    <strong>{l s='Your order will be sent as soon as we receive payment.' d='Modules.Wirepayment.Shop'}</strong>
-    <p>
-      {l s='If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
-    </p>
-{else}
-    <p class="warning">
-      {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
-    </p>
-{/if}
+<p>
+  {l s='Please specify your order reference %s in the bankwire description.' sprintf=[$reference] d='Modules.Wirepayment.Shop'}<br/>
+  {l s='We\'ve also sent you this information by e-mail.' d='Modules.Wirepayment.Shop'}
+</p>
+<strong>{l s='Your order will be sent as soon as we receive payment.' d='Modules.Wirepayment.Shop'}</strong>
+<p>
+  {l s='If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
+</p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There is no need to check for any order status, unless there was an error, this should never happen. Even if a module sneaked in some different order status, it's not a reason not to show payment information on confirmation screen.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/27689
| How to test?  | Order anything and see that everything displays correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
