### PR TITLE
Fix deprecated message with PHP 8.1

### DIFF
--- a/ps_wirepayment.php
+++ b/ps_wirepayment.php
@@ -86,8 +86,8 @@ class Ps_Wirepayment extends PaymentModule
 
         $this->extra_mail_vars = [
             '{bankwire_owner}' => $this->owner,
-            '{bankwire_details}' => nl2br($this->details),
-            '{bankwire_address}' => nl2br($this->address),
+            '{bankwire_details}' => nl2br($this->details ?: ''),
+            '{bankwire_address}' => nl2br($this->address ?: ''),
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since PHP 8.1, nl2br() cannot accept null as its first argument. This PR aims to give an empty string when the configuration is null. A similar PR has been made here #70.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | This PR is related to #70, tests are not needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
