### PR TITLE
fix: upgrade 2.1.1 file

### DIFF
--- a/upgrade/upgrade-2.1.1.php
+++ b/upgrade/upgrade-2.1.1.php
@@ -1,5 +1,5 @@
-
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This may seem silly, but having a line before the PhP tag is sometimes poorly managed by module upgrades. We can therefore end up with an error like this:```PHP Fatal error:  Uncaught RuntimeException: Failed to start the session because headers have already been sent by "/var/www/html/modules/ps_wirepayment/upgrade/upgrade-2.1.1.php" at line 1. in /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php:150```
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| How to test?  | You can try update then this PR is merged and another zip is created

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
