### PR TITLE
Fix module logo not displaying on configuration page

### DIFF
--- a/views/templates/hook/infos.tpl
+++ b/views/templates/hook/infos.tpl
@@ -18,7 +18,7 @@
  *}
 
 <div class="alert alert-info">
-  <img src="../modules/ps_wirepayment/logo.png" style="float:left; margin-right:15px;" height="60">
+  <img src="{$module_dir}logo.png" style="float:left; margin-right:15px;" height="60">
   <p><strong>{l s="This module allows you to accept secure payments by bank wire." d='Modules.Wirepayment.Admin'}</strong></p>
   <p>{l s="If the client chooses to pay by bank wire, the order status will change to 'Waiting for Payment'." d='Modules.Wirepayment.Admin'}</p>
   <p>{l s="That said, you must manually confirm the order upon receiving the bank wire." d='Modules.Wirepayment.Admin'}</p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The module configuration page rendered its logo from a **relative** path (`../modules/ps_wirepayment/logo.png`). That resolved correctly under the legacy `AdminModules` URL, but the PrestaShop module manager is now a Symfony route (`/admin-dev/improve/modules/manage/action/...`), so the relative path resolves to a non-existent admin URL and the logo fails to load. Switched to the absolute `{$module_dir}` path that `Module::display()` already assigns, so the logo resolves to `/modules/ps_wirepayment/logo.png` regardless of the back office URL. This is the same pattern already used by other bundled modules (e.g. `ps_googleanalytics`).
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#39813.
| How to test?  | Back office → Module Manager → configure **ps_wirepayment**. Before: the logo at the top of the info block is broken (the request to `.../manage/action/modules/ps_wirepayment/logo.png` 404s). After: the logo displays, served from `/modules/ps_wirepayment/logo.png` (HTTP 200).
