### PR TITLE
Rename the legacy bankwire order state reference to this module

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_wirepayment</name>
 	<displayName><![CDATA[Wire payment]]></displayName>
-	<version><![CDATA[2.2.1]]></version>
+	<version><![CDATA[2.2.2]]></version>
 	<description><![CDATA[Accept payments by bank transfer.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/ps_wirepayment.php
+++ b/ps_wirepayment.php
@@ -48,7 +48,7 @@ class Ps_Wirepayment extends PaymentModule
     {
         $this->name = 'ps_wirepayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.2.1';
+        $this->version = '2.2.2';
         $this->ps_versions_compliancy = ['min' => '1.7.6.0', 'max' => _PS_VERSION_];
         $this->author = 'PrestaShop';
         $this->controllers = ['payment', 'validation'];
@@ -101,7 +101,26 @@ class Ps_Wirepayment extends PaymentModule
             return false;
         }
 
+        $this->migrateLegacyOrderStateModuleName();
+
         return true;
+    }
+
+    /**
+     * Shops coming from PrestaShop 1.6 still name this module "bankwire" in the order state row of
+     * "Awaiting bank wire payment". OrderHistory resolves the module from that column to collect
+     * extra_mail_vars, and a name that no longer exists resolves to nothing, so the email goes out
+     * with {bankwire_owner}, {bankwire_details} and {bankwire_address} left as written.
+     *
+     * @return bool
+     */
+    public function migrateLegacyOrderStateModuleName()
+    {
+        return (bool) Db::getInstance()->update(
+            'order_state',
+            ['module_name' => pSQL($this->name)],
+            'module_name = \'bankwire\''
+        );
     }
 
     public function uninstall()

--- a/upgrade/upgrade-2.2.2.php
+++ b/upgrade/upgrade-2.2.2.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+/**
+ * @param Ps_Wirepayment $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_2_2($module)
+{
+    // Shops upgraded from 1.6 still carry "bankwire" in ps_order_state, which no longer resolves.
+    $module->migrateLegacyOrderStateModuleName();
+
+    return true;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On a shop upgraded from PrestaShop 1.6, the "Awaiting bank wire payment" order state still names this module `bankwire` in `ps_order_state.module_name`. `OrderHistory` resolves the module from that column to collect `extra_mail_vars`, and the old name no longer resolves, so the email reaches the customer with `{bankwire_owner}`, `{bankwire_details}` and `{bankwire_address}` left as written and no bank details to pay with. This adds a migration that renames the stale value, run both from `install()` and from a module upgrade.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#38993.
| How to test?  | See below.

### How to test

On a 9.x shop, put the order state back into its legacy state and check the module lookup that `OrderHistory` performs:

```sql
UPDATE ps_order_state SET module_name = 'bankwire' WHERE id_order_state = 10;
```

```php
$m = Module::getInstanceByName(
    Db::getInstance()->getValue('SELECT module_name FROM ps_order_state WHERE id_order_state = 10')
);
var_dump(Validate::isLoadedObject($m), count($m->extra_mail_vars ?? []));
```

Before the migration that prints `false` and `0`, which is why the placeholders are never replaced. After running it the column reads `ps_wirepayment` and the same lookup prints `true` and `3`. Measured on a 9.2.x shop:

```
PRIES=bankwire  migration=true  PO=ps_wirepayment
after: loaded=true extra_mail_vars=3
```

A fresh install is unaffected: `install-dev/data/xml/order_state.xml` already seeds `ps_wirepayment`, so the update matches no row and is a no-op.

### Why both install() and an upgrade file

The upgrade file covers shops where this module is upgraded in place. It does not cover a shop whose database still carries the old value but where the module is installed rather than upgraded, which is what happens when the 1.6 `bankwire` module was removed along the way. Calling the same method from `install()` covers that, and the statement is idempotent, so running it twice changes nothing.

The reporter reached the same conclusion in the issue after their first analysis: the missing piece is not the extra mail variables, which core already collects, but the stale module name that stops core from finding this module at all.
